### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,8 +10,8 @@
          io.aviso/pretty {:mvn/version "0.1.37"}
          deraen/sass4clj {:mvn/version "0.3.1"}
          metosin/bat-test {:mvn/version "0.4.2"}
-         codox {:mvn/version "0.10.6"}
-         eftest {:mvn/version "0.5.7"}
+         codox/codox {:mvn/version "0.10.6"}
+         eftest/eftest {:mvn/version "0.5.7"}
          javazoom/jlayer {:mvn/version "1.0.1"}
          ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}
 


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn